### PR TITLE
Patch for context in save method

### DIFF
--- a/addon/mixins/controllers/saving.js
+++ b/addon/mixins/controllers/saving.js
@@ -32,15 +32,15 @@ export default Ember.Mixin.create(
   validateAndSave: function() {
     var _this = this;
     var runCustomValidations = _this.runCustomValidations;
-    var save = _this.save;
+    // var save = _this.save;
 
     var resolve = function() {
       Ember.assert(
         'You need to specify a save method on this controller',
-        save
+        typeof _this.save === 'function'
       );
 
-      save();
+      _this.save();
     };
 
     var reject = function() {
@@ -52,11 +52,7 @@ export default Ember.Mixin.create(
     if (runCustomValidations && !runCustomValidations.then) {
       Ember.assert('runCustomValidations() must return a promise (e.g. return new Ember.RSVP.Promise()).');
     } else if (runCustomValidations) {
-      runCustomValidations().then(function() {
-        resolve();
-      }, function() {
-        reject();
-      });
+      runCustomValidations().then(resolve, reject);
     } else {
 
       /* Else save with normal ember-validations checks */

--- a/addon/mixins/controllers/saving.js
+++ b/addon/mixins/controllers/saving.js
@@ -32,7 +32,6 @@ export default Ember.Mixin.create(
   validateAndSave: function() {
     var _this = this;
     var runCustomValidations = _this.runCustomValidations;
-    // var save = _this.save;
 
     var resolve = function() {
       Ember.assert(

--- a/addon/mixins/views/submitting.js
+++ b/addon/mixins/views/submitting.js
@@ -62,7 +62,6 @@ export default Ember.Mixin.create({
   /* Private methods */
 
   _eventHandler: function(type) {
-    var _this = this;
     var controller = this.get('controller');
     var methodName = type + 'Handler';
     var handler = this[methodName];

--- a/addon/mixins/views/submitting.js
+++ b/addon/mixins/views/submitting.js
@@ -62,6 +62,7 @@ export default Ember.Mixin.create({
   /* Private methods */
 
   _eventHandler: function(type) {
+    var _this = this;
     var controller = this.get('controller');
     var methodName = type + 'Handler';
     var handler = this[methodName];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-easy-form-extensions",
-  "version": "0.2.1",
+  "version": "0.2.3",
   "description": "Extends Ember EasyForm into the view and controller layers of your Ember CLI app to provide easy event and action handling using mixins and components.",
   "directories": {
     "doc": "doc",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-easy-form-extensions",
-  "version": "0.2.3",
+  "version": "0.2.2",
   "description": "Extends Ember EasyForm into the view and controller layers of your Ember CLI app to provide easy event and action handling using mixins and components.",
   "directories": {
     "doc": "doc",

--- a/tests/dummy/app/resources/posts/new/controller.js
+++ b/tests/dummy/app/resources/posts/new/controller.js
@@ -10,6 +10,10 @@ export default Ember.ObjectController.extend(
     }
   },
 
+  save: function() {
+    console.log(this);
+  },
+
   cancel: function() {
     this.transitionToRoute('index');
   }


### PR DESCRIPTION
This PR fixes a bug that led to incorrect context (`this`) inside a controller's `save()` method.
